### PR TITLE
Enforce starting in HOME in chroot and run scripts in temporary chroot

### DIFF
--- a/lego
+++ b/lego
@@ -246,7 +246,7 @@ run_chroot()
 		colorecho red "WARNING: '$chroot_name' is a base-chroot. A temporary snapshot will be created and chroot'd to."
 		colorecho red "         THIS CHROOT ENVIRONMENT WILL BE DESTROYED AND LOST FOREVER WHEN YOU LOG OUT OF THE CHROOT."
 		colorecho red "         Use the new command to create a persistent work-chroot."
-		schroot -c $chroot_name
+		schroot -c $chroot_name -- $@
 		exitval=$?
 		colorecho yellow "NOTE: Temporary work-chroot environment permanently deleted."
 		return $exitval

--- a/lego
+++ b/lego
@@ -246,13 +246,13 @@ run_chroot()
 		colorecho red "WARNING: '$chroot_name' is a base-chroot. A temporary snapshot will be created and chroot'd to."
 		colorecho red "         THIS CHROOT ENVIRONMENT WILL BE DESTROYED AND LOST FOREVER WHEN YOU LOG OUT OF THE CHROOT."
 		colorecho red "         Use the new command to create a persistent work-chroot."
-		schroot -c $chroot_name -- $@
+		schroot -c $chroot_name --directory=${HOME} -- $@
 		exitval=$?
 		colorecho yellow "NOTE: Temporary work-chroot environment permanently deleted."
 		return $exitval
 	fi
 	# Must be good to switch to the persistent work-chroot
-	schroot -c $chroot_name -r -- $@
+	schroot -c $chroot_name -r --directory=${HOME} -- $@
 }
 
 	


### PR DESCRIPTION
### Summary of changes
1. Add ability to run scripts with arguments in a temporary chroot
2. Explicitly start all chroots in the /home/USERNAME directory

### Running scripts in temporary chroots
In some recent commits, you added the ability to run a specific script inside a chroot.  Arguments can be optionally used on the called script.  After finishing operations, the chroot exits with the return code of the invoked script.  To become more feature-complete, I added this option to running temporary chroots.  The called script with its arguments will be invoked and then delete the chroot after all operations have completed.

`lego run [template chroot] ls -l /usr/bin`

### Beginning in the HOME directory of a chroot
By default, lego enters a chroot in the /home/USERNAME directory.  When running lego via build automation, it becomes necessary to specify a defined working directory.  schroot's --directory option does just that.  It explicitly starts a chroot in the directory you give this option.  Now all chroots start in the HOME environment variable's directory to better define lego's behavior.